### PR TITLE
Annotate method error with alwaysThrows annotation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.4
+## 1.1.0
 
 * Add @alwaysThrows annotation to error method.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.4
+
+* Add @alwaysThrows annotation to error method.
+
 ## 1.0.3
 
 * Set max SDK version to `<3.0.0`, and adjust other dependencies.

--- a/lib/src/string_scanner.dart
+++ b/lib/src/string_scanner.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:charcode/charcode.dart';
+import 'package:meta/meta.dart';
 import 'package:source_span/source_span.dart';
 
 import 'exception.dart';
@@ -197,6 +198,7 @@ class StringScanner {
   /// position; if only [position] is passed, [length] defaults to 0.
   ///
   /// It's an error to pass [match] at the same time as [position] or [length].
+  @alwaysThrows
   void error(String message, {Match match, int position, int length}) {
     validateErrorArgs(string, match, position, length);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   charcode: ^1.1.0
-  meta: ^1.1.5
+  meta: ^1.1.0
   source_span: ^1.4.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: string_scanner
-version: 1.0.3
+version: 1.0.4
 
 description: A class for parsing strings using a sequence of patterns.
 author: Dart Team <misc@dartlang.org>
@@ -10,6 +10,7 @@ environment:
 
 dependencies:
   charcode: ^1.1.0
+  meta: ^1.1.5
   source_span: ^1.4.0
 
 dev_dependencies:


### PR DESCRIPTION
Adding this annotation prevents missing return hints in code where the error method is used.