### PR TITLE
Add optional `offset` argument to `StringScanner.peekCodePoint()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 1.2.1-wip
+## 1.3.0-wip
 
 * Require Dart 3.0.0
+* `StringScanner.peekCodePoint()` now accepts an optional `offset` argument like
+  `StringScanner.peekChar()`. 
 
 ## 1.2.0
 

--- a/lib/src/string_scanner.dart
+++ b/lib/src/string_scanner.dart
@@ -158,19 +158,23 @@ class StringScanner {
     return decodeSurrogatePair(first, next);
   }
 
-  /// Returns the Unicode code point immediately after [position].
+  /// Returns the Unicode code point [offset] away from [position].
   ///
   /// This works like [peekChar], except that it automatically handles UTF-16
   /// surrogate pairs. Specifically, if the next two code units form a surrogate
   /// pair, returns the corresponding Unicode code point.
   ///
+  /// [offset] defaults to zero, and may be negative to inspect already-consumed
+  /// characters.
+  ///
   /// If next two characters are not a surrogate pair, the next code unit is
   /// returned as-is, even if it's an unpaired surrogate.
-  int? peekCodePoint() {
-    final first = peekChar();
+  int? peekCodePoint([int? offset]) {
+    offset ??= 0;
+    final first = peekChar(offset);
     if (first == null || !isHighSurrogate(first)) return first;
 
-    final next = peekChar(1);
+    final next = peekChar(offset + 1);
     if (next == null || !isLowSurrogate(next)) return first;
 
     return decodeSurrogatePair(first, next);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: string_scanner
-version: 1.2.1-wip
+version: 1.3.0-wip
 description: A class for parsing strings using a sequence of patterns.
 repository: https://github.com/dart-lang/string_scanner
 

--- a/test/string_scanner_test.dart
+++ b/test/string_scanner_test.dart
@@ -154,6 +154,12 @@ void main() {
       expect(scanner.position, equals(0));
     });
 
+    test('peekCodePoint with an argument returns the nth character', () {
+      expect(scanner.peekCodePoint(4), equals(0x62));
+      expect(scanner.lastMatch, isNull);
+      expect(scanner.position, equals(0));
+    });
+
     test('a matching scanChar returns true moves forward', () {
       expect(scanner.scanChar($f), isTrue);
       expect(scanner.lastMatch, isNull);


### PR DESCRIPTION
Currently `StringScanner.peekChar()` accepts an optional argument of offset, but the new `StringScanner.peekCodePoint()` method doesn't. This PR aims to make `StringScanner.peekCodePoint()`'s behavior align more with that of `StringScanner.peekChar()`.

This is required if the [yaml](https://github.com/dart-lang/yaml) library is to migrate to `string_scanner ^1.2.0` to take advantage from the new codepoint related APIs.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
