### PR TITLE
Don't allow CR to act as newline when it is followed by LF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.4.0
+
+* Fix `LineScanner`'s handling of `\r\n`'s so that only the `\n` is treated as
+  the end of the line, preventing errors scanning zero-length matches when
+  between CR and LF.
+
 ## 1.3.0
 
 * Require Dart 3.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 1.4.0
 
-* Fix `LineScanner`'s handling of `\r\n`'s so that only the `\n` is treated as
-  the end of the line, preventing errors scanning zero-length matches when
-  between CR and LF.
+* Fix `LineScanner`'s handling of `\r\n`'s to preventing errors scanning
+  zero-length matches when between CR and LF. CR is treated as a new line only
+  if not immediately followed by a LF.
 
 ## 1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Fix `LineScanner`'s handling of `\r\n`'s to preventing errors scanning
   zero-length matches when between CR and LF. CR is treated as a new line only
   if not immediately followed by a LF.
+* Fix `LineScanner`'s updating of `column` when setting `position` if the
+  current position is not `0`.
 
 ## 1.3.0
 

--- a/lib/src/line_scanner.dart
+++ b/lib/src/line_scanner.dart
@@ -82,11 +82,10 @@ class LineScanner extends StringScanner {
         // character at that position itself (the next character) is a newline
         // we should not use it, so also offset to account for that.
         const currentCharOffset = -1;
-        // Find the last newline.
         final lastNewline = string.lastIndexOf(
             _newlineRegExp, newPosition + currentCharOffset + crOffset);
 
-        // No we need to know the offset after the newline. This is the index
+        // Now we need to know the offset after the newline. This is the index
         // above plus the length of the newline (eg. if we found `\r\n`) we need
         // to add two. However if no newline was found, that index is 0.
         final offsetAfterLastNewline = lastNewline == -1

--- a/lib/src/line_scanner.dart
+++ b/lib/src/line_scanner.dart
@@ -89,13 +89,13 @@ class LineScanner extends StringScanner {
         // No we need to know the offset after the newline. This is the index
         // above plus the length of the newline (eg. if we found `\r\n`) we need
         // to add two. However if no newline was found, that index is 0.
-        final offsetLastAfterNewline = lastNewline == -1
+        final offsetAfterLastNewline = lastNewline == -1
             ? 0
             : string[lastNewline] == '\r' && string[lastNewline + 1] == '\n'
                 ? lastNewline + 2
                 : lastNewline + 1;
 
-        _column = newPosition - offsetLastAfterNewline;
+        _column = newPosition - offsetAfterLastNewline;
       }
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: string_scanner
-version: 1.3.0
+version: 1.4.0
 description: A class for parsing strings using a sequence of patterns.
 repository: https://github.com/dart-lang/string_scanner
 

--- a/test/line_scanner_test.dart
+++ b/test/line_scanner_test.dart
@@ -46,6 +46,15 @@ void main() {
       expect(scanner.line, equals(2));
       expect(scanner.column, equals(1));
     });
+
+    test('scanning a zero length match between CR LF does not fail', () {
+      scanner.expect('foo\nbar\r');
+      expect(scanner.line, equals(1));
+      expect(scanner.column, equals(4));
+      scanner.expect(RegExp('(?!x)'));
+      expect(scanner.line, equals(1));
+      expect(scanner.column, equals(4));
+    });
   });
 
   group('readChar()', () {
@@ -231,6 +240,27 @@ void main() {
       scanner.position = 8; // "foo\nbar\r"
       expect(scanner.line, equals(1));
       expect(scanner.column, equals(4));
+    });
+
+    test('backward to between CR LF', () {
+      scanner.scan('foo\nbar\r\nbaz');
+      scanner.position = 8; // "foo\nbar\r"
+      expect(scanner.line, equals(1));
+      expect(scanner.column, equals(4));
+    });
+
+    test('backward to after CR LF', () {
+      scanner.scan('foo\nbar\r\nbaz');
+      scanner.position = 9; // "foo\nbar\r\n"
+      expect(scanner.line, equals(2));
+      expect(scanner.column, equals(0));
+    });
+
+    test('backward to before CR LF', () {
+      scanner.scan('foo\nbar\r\nbaz');
+      scanner.position = 7; // "foo\nbar"
+      expect(scanner.line, equals(1));
+      expect(scanner.column, equals(3));
     });
   });
 

--- a/test/line_scanner_test.dart
+++ b/test/line_scanner_test.dart
@@ -24,26 +24,51 @@ void main() {
       expect(scanner.column, equals(3));
     });
 
-    test('consuming a newline resets the column and increases the line', () {
+    test('consuming a LF resets the column and increases the line', () {
       scanner.expect('foo\nba');
       expect(scanner.line, equals(1));
       expect(scanner.column, equals(2));
     });
 
-    test('consuming multiple newlines resets the column and increases the line',
-        () {
+    test('consuming multiple LFs resets the column and increases the line', () {
       scanner.expect('foo\nbar\r\nb');
       expect(scanner.line, equals(2));
       expect(scanner.column, equals(1));
     });
 
-    test("consuming halfway through a CR LF doesn't count as a line", () {
+    test('consuming a CR LF increases the line only after the LF', () {
       scanner.expect('foo\nbar\r');
       expect(scanner.line, equals(1));
       expect(scanner.column, equals(4));
 
       scanner.expect('\nb');
       expect(scanner.line, equals(2));
+      expect(scanner.column, equals(1));
+    });
+
+    test('consuming a CR not followed by LF increases the line', () {
+      scanner = LineScanner('foo\nbar\rbaz');
+      scanner.expect('foo\nbar\r');
+      expect(scanner.line, equals(2));
+      expect(scanner.column, equals(0));
+
+      scanner.expect('b');
+      expect(scanner.line, equals(2));
+      expect(scanner.column, equals(1));
+    });
+
+    test('consuming a CR at the end increases the line', () {
+      scanner = LineScanner('foo\nbar\r');
+      scanner.expect('foo\nbar\r');
+      expect(scanner.line, equals(2));
+      expect(scanner.column, equals(0));
+      expect(scanner.isDone, isTrue);
+    });
+
+    test('consuming a mix of CR, LF, CR+LF increases the line', () {
+      scanner = LineScanner('0\n1\r2\r\n3');
+      scanner.expect('0\n1\r2\r\n3');
+      expect(scanner.line, equals(3));
       expect(scanner.column, equals(1));
     });
 
@@ -65,7 +90,7 @@ void main() {
       expect(scanner.column, equals(1));
     });
 
-    test('consuming a newline resets the column and increases the line', () {
+    test('consuming a LF resets the column and increases the line', () {
       scanner.expect('foo');
       expect(scanner.line, equals(0));
       expect(scanner.column, equals(3));
@@ -75,18 +100,51 @@ void main() {
       expect(scanner.column, equals(0));
     });
 
-    test("consuming halfway through a CR LF doesn't count as a line", () {
+    test('consuming a CR LF increases the line only after the LF', () {
+      scanner = LineScanner('foo\r\nbar');
+      scanner.expect('foo');
+      expect(scanner.line, equals(0));
+      expect(scanner.column, equals(3));
+
+      scanner.readChar();
+      expect(scanner.line, equals(0));
+      expect(scanner.column, equals(4));
+
+      scanner.readChar();
+      expect(scanner.line, equals(1));
+      expect(scanner.column, equals(0));
+    });
+
+    test('consuming a CR not followed by a LF increases the line', () {
+      scanner = LineScanner('foo\nbar\rbaz');
       scanner.expect('foo\nbar');
       expect(scanner.line, equals(1));
       expect(scanner.column, equals(3));
 
       scanner.readChar();
+      expect(scanner.line, equals(2));
+      expect(scanner.column, equals(0));
+    });
+
+    test('consuming a CR at the end increases the line', () {
+      scanner = LineScanner('foo\nbar\r');
+      scanner.expect('foo\nbar');
       expect(scanner.line, equals(1));
-      expect(scanner.column, equals(4));
+      expect(scanner.column, equals(3));
 
       scanner.readChar();
       expect(scanner.line, equals(2));
       expect(scanner.column, equals(0));
+    });
+
+    test('consuming a mix of CR, LF, CR+LF increases the line', () {
+      scanner = LineScanner('0\n1\r2\r\n3');
+      for (var i = 0; i < scanner.string.length; i++) {
+        scanner.readChar();
+      }
+
+      expect(scanner.line, equals(3));
+      expect(scanner.column, equals(1));
     });
   });
 
@@ -131,7 +189,7 @@ void main() {
       expect(scanner.column, equals(1));
     });
 
-    test('consuming a newline resets the column and increases the line', () {
+    test('consuming a LF resets the column and increases the line', () {
       scanner.expect('foo');
       expect(scanner.line, equals(0));
       expect(scanner.column, equals(3));
@@ -141,7 +199,7 @@ void main() {
       expect(scanner.column, equals(0));
     });
 
-    test("consuming halfway through a CR LF doesn't count as a line", () {
+    test('consuming a CR LF increases the line only after the LF', () {
       scanner.expect('foo\nbar');
       expect(scanner.line, equals(1));
       expect(scanner.column, equals(3));
@@ -153,6 +211,38 @@ void main() {
       scanner.scanChar($lf);
       expect(scanner.line, equals(2));
       expect(scanner.column, equals(0));
+    });
+
+    test('consuming a CR not followed by LF increases the line', () {
+      scanner = LineScanner('foo\rbar');
+      scanner.expect('foo');
+      expect(scanner.line, equals(0));
+      expect(scanner.column, equals(3));
+
+      scanner.scanChar($cr);
+      expect(scanner.line, equals(1));
+      expect(scanner.column, equals(0));
+    });
+
+    test('consuming a CR at the end increases the line', () {
+      scanner = LineScanner('foo\r');
+      scanner.expect('foo');
+      expect(scanner.line, equals(0));
+      expect(scanner.column, equals(3));
+
+      scanner.scanChar($cr);
+      expect(scanner.line, equals(1));
+      expect(scanner.column, equals(0));
+    });
+
+    test('consuming a mix of CR, LF, CR+LF increases the line', () {
+      scanner = LineScanner('0\n1\r2\r\n3');
+      for (var i = 0; i < scanner.string.length; i++) {
+        scanner.scanChar(scanner.string[i].codeUnits.single);
+      }
+
+      expect(scanner.line, equals(3));
+      expect(scanner.column, equals(1));
     });
   });
 
@@ -210,9 +300,39 @@ void main() {
   });
 
   group('position=', () {
-    test('forward through newlines sets the line and column', () {
-      scanner.position = 10; // "foo\nbar\r\nb"
+    test('forward through LFs sets the line and column', () {
+      scanner = LineScanner('foo\nbar\nbaz');
+      scanner.position = 9; // "foo\nbar\nb"
       expect(scanner.line, equals(2));
+      expect(scanner.column, equals(1));
+    });
+
+    test('forward through CR LFs sets the line and column', () {
+      scanner = LineScanner('foo\r\nbar\r\nbaz');
+      scanner.position = 11; // "foo\r\nbar\r\nb"
+      expect(scanner.line, equals(2));
+      expect(scanner.column, equals(1));
+    });
+
+    test('forward through CR not followed by LFs sets the line and column', () {
+      scanner = LineScanner('foo\rbar\rbaz');
+      scanner.position = 9; // "foo\rbar\rb"
+      expect(scanner.line, equals(2));
+      expect(scanner.column, equals(1));
+    });
+
+    test('forward through CR at end sets the line and column', () {
+      scanner = LineScanner('foo\rbar\r');
+      scanner.position = 8; // "foo\rbar\r"
+      expect(scanner.line, equals(2));
+      expect(scanner.column, equals(0));
+    });
+
+    test('forward through a mix of CR, LF, CR+LF sets the line and column', () {
+      scanner = LineScanner('0\n1\r2\r\n3');
+      scanner.position = scanner.string.length;
+
+      expect(scanner.line, equals(3));
       expect(scanner.column, equals(1));
     });
 
@@ -222,11 +342,47 @@ void main() {
       expect(scanner.column, equals(2));
     });
 
-    test('backward through newlines sets the line and column', () {
-      scanner.scan('foo\nbar\r\nbaz');
+    test('backward through LFs sets the line and column', () {
+      scanner = LineScanner('foo\nbar\nbaz');
+      scanner.scan('foo\nbar\nbaz');
       scanner.position = 2; // "fo"
       expect(scanner.line, equals(0));
       expect(scanner.column, equals(2));
+    });
+
+    test('backward through CR LFs sets the line and column', () {
+      scanner = LineScanner('foo\r\nbar\r\nbaz');
+      scanner.scan('foo\r\nbar\r\nbaz');
+      scanner.position = 2; // "fo"
+      expect(scanner.line, equals(0));
+      expect(scanner.column, equals(2));
+    });
+
+    test('backward through CR not followed by LFs sets the line and column',
+        () {
+      scanner = LineScanner('foo\rbar\rbaz');
+      scanner.scan('foo\rbar\rbaz');
+      scanner.position = 2; // "fo"
+      expect(scanner.line, equals(0));
+      expect(scanner.column, equals(2));
+    });
+
+    test('backward through CR at end sets the line and column', () {
+      scanner = LineScanner('foo\rbar\r');
+      scanner.scan('foo\rbar\r');
+      scanner.position = 2; // "fo"
+      expect(scanner.line, equals(0));
+      expect(scanner.column, equals(2));
+    });
+
+    test('backward through a mix of CR, LF, CR+LF sets the line and column',
+        () {
+      scanner = LineScanner('0\n1\r2\r\n3');
+      scanner.scan(scanner.string);
+
+      scanner.position = 1;
+      expect(scanner.line, equals(0));
+      expect(scanner.column, equals(1));
     });
 
     test('backward through no newlines sets the column', () {


### PR DESCRIPTION
This fixes an error I encountered (https://github.com/dart-lang/string_scanner/issues/80) when scanning a zero-length match when between a CR and LF. It removes some special handling of \r's that seemed to complicate things. Now, \r is just ignored and only \n is treated as the end of a line.

Note: This partially reverts some changes made in 27d20a3ed710eafbbe26d5c694e583e703ad5916 that seemed to be the cause of the error - however the changes added in that change still pass with my changes, and I added some additional tests.

Fixes https://github.com/dart-lang/string_scanner/issues/80

